### PR TITLE
Symlink cypress firmware to brcm directory

### DIFF
--- a/brcm/brcmfmac4373-clm-sa.clm_blob
+++ b/brcm/brcmfmac4373-clm-sa.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-clm-sa.clm_blob

--- a/brcm/brcmfmac4373-sa.txt
+++ b/brcm/brcmfmac4373-sa.txt
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-sa.txt

--- a/brcm/brcmfmac4373-sdio-prod_v13.10.246.265.bin
+++ b/brcm/brcmfmac4373-sdio-prod_v13.10.246.265.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-sdio-prod_v13.10.246.265.bin

--- a/brcm/brcmfmac4373-sdio.bin
+++ b/brcm/brcmfmac4373-sdio.bin
@@ -1,0 +1,1 @@
+brcmfmac4373-sdio-prod_v13.10.246.265.bin

--- a/brcm/brcmfmac4373-sdio.clm_blob
+++ b/brcm/brcmfmac4373-sdio.clm_blob
@@ -1,0 +1,1 @@
+brcmfmac4373-clm-sa.clm_blob

--- a/brcm/brcmfmac4373-sdio.txt
+++ b/brcm/brcmfmac4373-sdio.txt
@@ -1,0 +1,1 @@
+brcmfmac4373-sa.txt


### PR DESCRIPTION
To work with current mainline kernel version of the brcmfmac driver