### PR TITLE
Symlink cypress firmware to brcm directory

### DIFF
--- a/brcm/brcmfmac4373-sdio.bin
+++ b/brcm/brcmfmac4373-sdio.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-sdio.bin

--- a/brcm/brcmfmac4373-sdio.clm_blob
+++ b/brcm/brcmfmac4373-sdio.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-sdio.clm_blob

--- a/brcm/brcmfmac4373-sdio.txt
+++ b/brcm/brcmfmac4373-sdio.txt
@@ -1,0 +1,1 @@
+../cypress/cyfmac4373-sdio.txt


### PR DESCRIPTION
To also work with current mainline kernel version of the brcmfmac driver